### PR TITLE
fix: write binary as hex strings in mysql text protocol

### DIFF
--- a/mysql/src/writers.rs
+++ b/mysql/src/writers.rs
@@ -22,6 +22,8 @@ use crate::myc::io::WriteMysqlExt;
 use crate::packet_writer::PacketWriter;
 use crate::{Column, ErrorKind, OkResponse};
 
+const BIN_GENERAL_CI: u16 = 0x3f;
+
 pub(crate) async fn write_eof_packet<W: AsyncWrite + Unpin>(
     w: &mut PacketWriter<W>,
     s: StatusFlags,
@@ -123,7 +125,6 @@ where
     W: AsyncWrite + Unpin,
 {
     for c in i {
-        use crate::myc::constants::UTF8_GENERAL_CI;
         w.write_lenenc_str(b"def")?;
         w.write_lenenc_str(b"")?;
         w.write_lenenc_str(c.table.as_bytes())?;
@@ -131,7 +132,7 @@ where
         w.write_lenenc_str(c.column.as_bytes())?;
         w.write_lenenc_str(b"")?;
         w.write_lenenc_int(0xC)?;
-        w.write_u16::<LittleEndian>(UTF8_GENERAL_CI)?;
+        w.write_u16::<LittleEndian>(BIN_GENERAL_CI)?;
         w.write_u32::<LittleEndian>(1024)?;
         w.write_u8(c.coltype as u8)?;
         w.write_u16::<LittleEndian>(c.colflags.bits())?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently the text protocol write binary value directly into the packet, thus the client would get the original binary values and display it like this:
![image](https://github.com/user-attachments/assets/8a453332-48ef-4ddd-88be-1d6f18cc8a51)

But actually the mysql client display the binary value as hex strings (MySQL (client v8.4.0, server v9.0.1)):
![image](https://github.com/user-attachments/assets/eb8673d1-c633-4291-8cb2-c434a937b6f5)

Through the client source code it only parse binary values as hex strings when using binary charset:

```C++
// See https://github.com/mysql/mysql-server/blob/596f0d238489a9cf9f43ce1ff905984f58d227b6/client/mysql.cc
// L3916-L3918 and L4033-L4034
tatic bool is_binary_field(MYSQL_FIELD *field) {
  return (
      (field->charsetnr == 63) &&
// ...
// when write results
if (opt_binhex && is_binary_field(field))
    print_as_hex(PAGER, cur[off], lengths[off], field_max_length);
```

So I wonder if it's proper to directly write hex strings when using text protocol :)